### PR TITLE
feat: load global styles before tokens

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -47,7 +47,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       @media (prefers-reduced-motion: reduce){.fade-in{transition:none}}
     </style>
 
-    <!-- Non-critical CSS loaded asynchronously -->
+    <!-- Global styles -->
+    <link rel="stylesheet" href="/styles/global.css">
     <link rel="stylesheet" href="/styles/tokens.css" media="print" onload="this.media='all'">
     <noscript><link rel="stylesheet" href="/styles/tokens.css"></noscript>
 


### PR DESCRIPTION
## Summary
- load global.css before tokens utilities in BaseLayout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaeff66ef0832a9f795e828194f9eb