### PR TITLE
Fix nodemailer transporter initialization in send-email API

### DIFF
--- a/api/send-email.js
+++ b/api/send-email.js
@@ -17,7 +17,7 @@ export default async function handler(req, res) {
     }
 
     // Create transporter using environment variables
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST || 'smtp.gmail.com',
       port: process.env.SMTP_PORT || 587,
       secure: false, // true for 465, false for other ports


### PR DESCRIPTION
## Summary
- use nodemailer.createTransport instead of createTransporter in send-email API

## Testing
- `npm test`
- `node --input-type=module` (send test email via jsonTransport)


------
https://chatgpt.com/codex/tasks/task_e_68aaeff8c374832abc03a956363e5a3c