### PR TITLE
Ensure preload link uses proper attributes

### DIFF
--- a/src/components/OptimizedImage.astro
+++ b/src/components/OptimizedImage.astro
@@ -177,8 +177,9 @@ const aspectRatio = height / width * 100;
                 const link = document.createElement('link');
                 link.rel = 'preload';
                 link.as = 'image';
-                link.hrefset = source.srcset;
-                link.sizes = source.sizes || '';
+                link.href = source.srcset;
+                link.imagesrcset = source.srcset;
+                link.imagesizes = source.sizes || '';
                 document.head.appendChild(link);
               }
             });


### PR DESCRIPTION
## Summary
- Fix preload logic in OptimizedImage to set `href`, `imagesrcset`, and `imagesizes` on link element

## Testing
- `npm test`
- `npm run build`
- `node` script to simulate IntersectionObserver and confirm `imagesrcset`/`imagesizes` are set

------
https://chatgpt.com/codex/tasks/task_e_68aaeffa5704832aa50eb87b5365666f