### PR TITLE
Self-host Inter fonts and remove Google Fonts

### DIFF
--- a/src/components/SEOEnhancer.astro
+++ b/src/components/SEOEnhancer.astro
@@ -200,8 +200,6 @@
 <meta name="business:service_area:geo_radius" content="321868" />
 
 <!-- Enhanced Performance -->
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link rel="preload" href="/photos/logos/lccontainer-logo-transparent-400.png" as="image" type="image/png" />
 
 <!-- Structured Data for Current Page -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,11 +51,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <link rel="stylesheet" href="/styles/tokens.css" media="print" onload="this.media='all'">
     <noscript><link rel="stylesheet" href="/styles/tokens.css"></noscript>
 
-    <!-- Font optimization -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;500;600;700&display=swap"></noscript>
+    <!-- Self-hosted Inter font via @fontsource -->
 
     <!-- DNS prefetch for external domains -->
     <link rel="dns-prefetch" href="https://lccontainer.com">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,4 @@
 /* Fonts - Local hosting for performance */
-@import "@fontsource/inter/300.css";
 @import "@fontsource/inter/400.css";
 @import "@fontsource/inter/500.css";
 @import "@fontsource/inter/600.css";


### PR DESCRIPTION
## Summary
- Remove Google Fonts link tags, relying on self-hosted Inter via `@fontsource`.
- Drop unnecessary font weight imports to align with used weights.
- Clean up SEO enhancer to avoid Google font preconnects.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaeffacc5c832aad55612cfa5873dc