### PR TITLE
feat: add alt prop to lightbox

### DIFF
--- a/src/components/Lightbox.astro
+++ b/src/components/Lightbox.astro
@@ -1,5 +1,6 @@
 ---
 const id = Astro.props.id ?? "lb";
+const alt = Astro.props.alt ?? "";
 ---
 
 <dialog id={id} class="backdrop:bg-black/80 p-0 rounded-2xl w-[min(92vw,1000px)]">
@@ -7,7 +8,7 @@ const id = Astro.props.id ?? "lb";
     <button class="px-3 py-2 rounded-lg bg-white/10 text-white border border-brand-line hover:bg-white/20" aria-label="Close lightbox">✕</button>
   </form>
   <div class="relative">
-    <img id={`${id}-img`} alt="" class="w-full h-auto block max-h-[80vh] object-contain bg-black/40" />
+    <img id={`${id}-img`} alt={alt} class="w-full h-auto block max-h-[80vh] object-contain bg-black/40" />
     <div class="p-4 text-sm text-ink-muted bg-brand-black/80 border-t border-brand-line">
       <div id={`${id}-title`} class="text-ink font-semibold"></div>
       <div id={`${id}-caption`} class=""></div>
@@ -21,11 +22,11 @@ const id = Astro.props.id ?? "lb";
   const titleEl = document.getElementById({id:JSON.stringify(id + "-title")});
   const capEl = document.getElementById({id:JSON.stringify(id + "-caption")});
   
-  // Public API: window.openLightbox({ src, title, caption })
+  // Public API: window.openLightbox({ src, alt, title, caption })
   window.openLightbox = (data) => {
     if(!dialog || !img) return;
     img.src = data.src || "";
-    img.alt = data.title || "";
+    img.alt = data.alt || data.title || "";
     if (titleEl) titleEl.textContent = data.title || "";
     if (capEl) capEl.textContent = data.caption || "";
     dialog.showModal();

--- a/src/pages/custom-builds.astro
+++ b/src/pages/custom-builds.astro
@@ -33,7 +33,7 @@ const TAGS: Tag[] = ["Doors","Windows","Insulation","Paint/Branding","Power/HVAC
         <article class="glass overflow-hidden hover-lift">
                       <button
               class="block relative aspect-[4/3] w-full text-left image-overlay"
-              onClick={`openLightbox(${JSON.stringify({ src: item.photo, title: item.title, caption: item.caption })})`}
+              onClick={`openLightbox(${JSON.stringify({ src: item.photo, alt: item.title, title: item.title, caption: item.caption })})`}
               aria-label={`Open ${item.title}`}
             >
               <img src={item.photo} alt={item.title} class="absolute inset-0 h-full w-full object-cover" loading="lazy" />
@@ -92,7 +92,7 @@ const TAGS: Tag[] = ["Doors","Windows","Insulation","Paint/Branding","Power/HVAC
              grid.innerHTML = items.map(item => `
          <article class="glass overflow-hidden hover-lift" id="${item.id}">
                      <button class="block relative aspect-[4/3] w-full text-left image-overlay" aria-label="Open ${item.title}"
-             onclick='openLightbox(${JSON.stringify({ src: item.photo, title: item.title, caption: item.caption })})'>
+             onclick='openLightbox(${JSON.stringify({ src: item.photo, alt: item.title, title: item.title, caption: item.caption })})'>
              <img src="${item.photo}" alt="${item.title}" class="absolute inset-0 h-full w-full object-cover" loading="lazy" />
            </button>
           <div class="p-4">

--- a/src/pages/inventory.astro
+++ b/src/pages/inventory.astro
@@ -61,7 +61,7 @@ const desc = "Browse shipping containers: 20', 40', Standard and High Cube. New 
         <article class="glass p-0 flex flex-col overflow-hidden hover-lift" role="article">
           <button 
             class="relative h-44 bg-[radial-gradient(ellipse_at_center,rgba(178,34,34,.18),transparent_60%)] image-overlay cursor-pointer overflow-hidden"
-            onClick={`openLightbox(${JSON.stringify({ src: item.photos[0], title: item.title, caption: item.blurb })})`}
+            onClick={`openLightbox(${JSON.stringify({ src: item.photos[0], alt: item.title, title: item.title, caption: item.blurb })})`}
             aria-label={`Enlarge ${item.title} image`}
           >
             <OptimizedImage 
@@ -158,7 +158,7 @@ const desc = "Browse shipping containers: 20', 40', Standard and High Cube. New 
         article.innerHTML = `
           <button 
             class="relative h-44 bg-[radial-gradient(ellipse_at_center,rgba(178,34,34,.18),transparent_60%)] image-overlay cursor-pointer overflow-hidden"
-            onClick="openLightbox(${JSON.stringify({ src: item.photos[0], title: item.title, caption: item.blurb })})"
+            onClick="openLightbox(${JSON.stringify({ src: item.photos[0], alt: item.title, title: item.title, caption: item.blurb })})"
             aria-label="Enlarge ${item.title} image"
           >
             <div class="optimized-image-container h-full w-full">

--- a/src/pages/inventory/[id].astro
+++ b/src/pages/inventory/[id].astro
@@ -32,7 +32,7 @@ const desc = `${item.title}: ${item.blurb} · ${item.condition}. From $${item.pr
           <button 
             id="cimg-btn"
             class="absolute inset-0 w-full h-full cursor-pointer image-overlay"
-            onClick={`openLightbox(${JSON.stringify({ src: item.photos[0], title: item.title, caption: item.blurb })})`}
+            onClick={`openLightbox(${JSON.stringify({ src: item.photos[0], alt: item.title, title: item.title, caption: item.blurb })})`}
             aria-label={`Enlarge ${item.title} image`}
           >
             <img id="cimg" src={item.photos[0]} alt={item.title} class="h-full w-full object-cover" loading="eager" onerror="this.style.display='none'" />
@@ -127,6 +127,7 @@ const desc = `${item.title}: ${item.blurb} · ${item.condition}. From $${item.pr
       if(cimgBtn) {
         cimgBtn.onclick = () => openLightbox({
           src: photos[idx] || "",
+          alt: document.querySelector('h1')?.textContent || "",
           title: document.querySelector('h1')?.textContent || "",
           caption: document.querySelector('.text-ink-muted')?.textContent || ""
         });


### PR DESCRIPTION
## Summary
- expose `alt` prop in Lightbox component and update global `openLightbox` API
- include descriptive `alt` text when invoking `openLightbox` in inventory and custom build pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf0d2900c832ab5e2b587ecd46325