### PR TITLE
Add favicon links to base layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,7 +16,10 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
-    
+
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
+
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />


### PR DESCRIPTION
## Summary
- reference favicon and apple touch icon in base layout head

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf0d30ef0832a895c8636c4098f20