### PR TITLE
Cleanup throttled IPs after window

### DIFF
--- a/src/pages/api/lead.ts
+++ b/src/pages/api/lead.ts
@@ -19,6 +19,8 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       return new Response(JSON.stringify({ ok:false, error:"Too many requests. Try again shortly." }), { status: 429 });
     }
     recentIps.set(ip, now);
+    // Remove this IP after the throttle window to avoid unbounded growth
+    setTimeout(() => recentIps.delete(ip), THROTTLE_MS);
 
     const raw = await request.json();
     const parsed = leadSchema.safeParse(raw);


### PR DESCRIPTION
## Summary
- remove IP entries from throttle map after THROTTLE_MS using setTimeout
- document cleanup to prevent unbounded memory growth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf17daa5c832a9ef3568b3d739321