### PR TITLE
fix: use nodemailer createTransport

### DIFF
--- a/api/send-email.js
+++ b/api/send-email.js
@@ -17,7 +17,7 @@ export default async function handler(req, res) {
     }
 
     // Create transporter using environment variables
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST || 'smtp.gmail.com',
       port: process.env.SMTP_PORT || 587,
       secure: false, // true for 465, false for other ports


### PR DESCRIPTION
## Summary
- replace `nodemailer.createTransporter` with proper `createTransport` in email API
- verify email sending works using a local SMTP server

## Testing
- `node test-send-email.mjs` (local SMTP server) *not committed*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf17f6a14832abee8d2df2315c9e8